### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-07-08
+
 ### Added
 - Test suite (pytest) covering config loading, ID/server validation, the Kerlink iStation
   driver, and CLI dispatch.
@@ -20,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Developer tooling: Ruff (lint + format), mypy, pre-commit, `.editorconfig`.
 - Contributor docs: `CONTRIBUTING.md`, issue and pull request templates.
 - `CLAUDE.md` and `.claude/settings.json` for AI-assisted development.
+- Dependabot updates: `actions/checkout` v4→v7, `actions/setup-python` v5→v6,
+  `types-paramiko` 4.x→5.x (dev).
 
 ### Fixed
 - Narrowed bare `except:` blocks so `KeyboardInterrupt` / `SystemExit` are no longer swallowed.
@@ -37,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release: interactive CLI for configuring the Kerlink Wirnet™ iStation gateway
   (server, network preferences, cellular, reboot) over SSH/SCP.
 
-[Unreleased]: https://github.com/jakubawieruk/gatcon/compare/v0.0.2...HEAD
+[Unreleased]: https://github.com/jakubawieruk/gatcon/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/jakubawieruk/gatcon/compare/v0.0.2...v0.1.0
 [0.0.2]: https://github.com/jakubawieruk/gatcon/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/jakubawieruk/gatcon/releases/tag/v0.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gatcon"
-version = "0.0.2"
+version = "0.1.0"
 description = "This is the LoRaWAN Gateway configurator CLI tool"
 authors = ["jakubawieruk <jakubawieruk@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Release v0.1.0

Bumps the version to **0.1.0** and dates the changelog. Minor bump (not a patch) because the minimum supported Python was raised from 3.12 to 3.13.

### Highlights (since v0.0.2)
- **Added:** pytest test suite, GitHub Actions CI (Ruff, mypy, pytest on 3.13/3.14), Dependabot config.
- **Changed:** Python 3.13+ required (3.14 supported); `cryptography` dropped as a direct dependency; Ruff/mypy/pre-commit tooling; contributor docs.
- **Fixed:** bare `except:` blocks no longer swallow `KeyboardInterrupt`/`SystemExit`; SCP helpers guard the connection they use; `confiig_path` typo in `config.load_config`.

Full details in [CHANGELOG.md](https://github.com/jakubawieruk/gatcon/blob/release/v0.1.0/CHANGELOG.md).

Locally verified: 21 tests pass, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)